### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.0
 
-      - uses: Vampire/setup-wsl@v2
+      - uses: Vampire/setup-wsl@v2.0.1
         with:
           additional-packages:
             git
@@ -44,7 +44,7 @@ jobs:
             protobuf-compile
         if: matrix.os == 'windows-latest'
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: nightly
@@ -54,22 +54,22 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.3.1
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v1.0.1
         with:
           command: build
           args: '--release'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.1](https://github.com/actions/cache/releases/tag/v3.3.1)** on 2023-03-13T05:05:19Z
* **[Vampire/setup-wsl](https://github.com/Vampire/setup-wsl)** published a new release **[v2.0.1](https://github.com/Vampire/setup-wsl/releases/tag/v2.0.1)** on 2023-02-17T12:47:15Z
* **[actions-rs/toolchain](https://github.com/actions-rs/toolchain)** published a new release **[v1.0.6](https://github.com/actions-rs/toolchain/releases/tag/v1.0.6)** on 2020-03-24T13:30:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
* **[actions-rs/cargo](https://github.com/actions-rs/cargo)** published a new release **[v1.0.1](https://github.com/actions-rs/cargo/releases/tag/v1.0.1)** on 2019-09-15T09:21:00Z
